### PR TITLE
FEAT : 인증인가를 도입한다

### DIFF
--- a/src/main/java/com/example/univeus/common/annotation/Auth.java
+++ b/src/main/java/com/example/univeus/common/annotation/Auth.java
@@ -1,0 +1,11 @@
+package com.example.univeus.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/example/univeus/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/univeus/common/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.univeus.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+    /**
+     * auth
+     */
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH-001", "만료된 refresh token 입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-002", "refresh token이 존재하지 않습니다."),
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH-002", "access token이 존재하지 않습니다."),
+    AUTH_BAD_REQUEST(HttpStatus.BAD_REQUEST, "AUTH-003", "접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String errorMessage;
+}

--- a/src/main/java/com/example/univeus/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/univeus/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.example.univeus.common.handler;
+
+
+import com.example.univeus.common.response.ErrorResponse;
+import com.example.univeus.domain.auth.exception.AuthException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ErrorResponse> handleAuthException(AuthException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                ex.getHttpStatus().value(),
+                ex.getCode(),
+                ex.getMessage()
+        );
+        return new ResponseEntity<>(errorResponse, ex.getHttpStatus());
+    }
+}

--- a/src/main/java/com/example/univeus/common/resolver/AuthenticationResolver.java
+++ b/src/main/java/com/example/univeus/common/resolver/AuthenticationResolver.java
@@ -1,0 +1,59 @@
+package com.example.univeus.common.resolver;
+
+
+import static com.example.univeus.common.exception.ErrorCode.*;
+
+import com.example.univeus.common.annotation.Auth;
+import com.example.univeus.domain.auth.RefreshTokenExtractor;
+import com.example.univeus.domain.auth.TokenExtractor;
+import com.example.univeus.domain.auth.TokenProvider;
+import com.example.univeus.domain.auth.exception.AuthException;
+import com.example.univeus.domain.auth.exception.TokenException;
+import com.example.univeus.domain.auth.model.Accessor;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationResolver implements HandlerMethodArgumentResolver {
+
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenExtractor refreshTokenExtractor;
+    private final TokenExtractor tokenExtractor;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Auth.class);
+    }
+
+    @Override
+    public Accessor resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                    NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        if (request == null) {
+            throw new AuthException(AUTH_BAD_REQUEST);
+        }
+
+        try {
+            String refreshTokenValue = refreshTokenExtractor.extractToken(request.getCookies());
+            String accessTokenValue = tokenExtractor.extractToken(request.getHeader("Authorization"));
+
+            // 토큰을 검증에서 expired 되면 throw 한다
+            tokenProvider.verify(refreshTokenValue);
+            tokenProvider.verify(accessTokenValue);
+
+            Long memberId = Long.valueOf(tokenProvider.getSubject(accessTokenValue));
+            return Accessor.member(memberId);
+
+        } catch (TokenException e) {
+            return Accessor.guest();
+        }
+    }
+}

--- a/src/main/java/com/example/univeus/common/response/ErrorResponse.java
+++ b/src/main/java/com/example/univeus/common/response/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.example.univeus.common.response;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/univeus/domain/auth/RefreshTokenExtractor.java
+++ b/src/main/java/com/example/univeus/domain/auth/RefreshTokenExtractor.java
@@ -1,0 +1,25 @@
+package com.example.univeus.domain.auth;
+
+import com.example.univeus.common.exception.ErrorCode;
+import com.example.univeus.domain.auth.exception.TokenException;
+import com.example.univeus.domain.auth.service.RefreshTokenService;
+import jakarta.servlet.http.Cookie;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenExtractor {
+    private static final String TOKEN_NAME = "refresh-token";
+    private final RefreshTokenService refreshTokenService;
+
+    public String extractToken(Cookie[] cookies) {
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(TOKEN_NAME))
+                .map(Cookie::getValue)
+                .filter(refreshTokenService::isExist)
+                .findFirst()
+                .orElseThrow(() -> new TokenException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/univeus/domain/auth/TokenExtractor.java
+++ b/src/main/java/com/example/univeus/domain/auth/TokenExtractor.java
@@ -1,0 +1,18 @@
+package com.example.univeus.domain.auth;
+
+import static com.example.univeus.common.exception.ErrorCode.*;
+
+import com.example.univeus.domain.auth.exception.TokenException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenExtractor {
+    private static final String TYPE = "Bearer ";
+
+    public String extractToken(String headerValue) {
+        if (headerValue == null || !headerValue.startsWith(TYPE)) {
+            throw new TokenException(ACCESS_TOKEN_NOT_FOUND);
+        }
+        return headerValue.substring(TYPE.length());
+    }
+}

--- a/src/main/java/com/example/univeus/domain/auth/exception/AuthException.java
+++ b/src/main/java/com/example/univeus/domain/auth/exception/AuthException.java
@@ -1,0 +1,24 @@
+package com.example.univeus.domain.auth.exception;
+
+import com.example.univeus.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class AuthException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode.getErrorMessage());
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+
+    public String getCode() {
+        return errorCode.getCode();
+    }
+}

--- a/src/main/java/com/example/univeus/domain/auth/exception/TokenException.java
+++ b/src/main/java/com/example/univeus/domain/auth/exception/TokenException.java
@@ -1,0 +1,14 @@
+package com.example.univeus.domain.auth.exception;
+
+import com.example.univeus.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class TokenException extends AuthException {
+    private final ErrorCode errorCode;
+
+    public TokenException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/univeus/domain/auth/model/Accessor.java
+++ b/src/main/java/com/example/univeus/domain/auth/model/Accessor.java
@@ -1,0 +1,27 @@
+package com.example.univeus.domain.auth.model;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class Accessor {
+    private static final Long GUEST_ID = 0L;
+
+    private final AccessorRole accessorRole;
+    private final Long memberId;
+
+    public static Accessor member(Long memberId) {
+        return Accessor.of(AccessorRole.MEMBER, memberId);
+    }
+
+    public static Accessor guest() {
+        return Accessor.of(AccessorRole.GUEST, GUEST_ID);
+    }
+
+    public static Accessor admin(Long memberId) {
+        return Accessor.of(AccessorRole.ADMIN, memberId);
+    }
+
+    public static Accessor of(AccessorRole accessRole, Long memberId) {
+        return new Accessor(accessRole, memberId);
+    }
+}

--- a/src/main/java/com/example/univeus/domain/auth/model/AccessorRole.java
+++ b/src/main/java/com/example/univeus/domain/auth/model/AccessorRole.java
@@ -1,0 +1,7 @@
+package com.example.univeus.domain.auth.model;
+
+public enum AccessorRole {
+    GUEST,
+    MEMBER,
+    ADMIN;
+}

--- a/src/main/java/com/example/univeus/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/univeus/domain/auth/service/RefreshTokenService.java
@@ -1,0 +1,5 @@
+package com.example.univeus.domain.auth.service;
+
+public interface RefreshTokenService {
+    Boolean isExist(String id);
+}

--- a/src/main/java/com/example/univeus/domain/auth/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/example/univeus/domain/auth/service/RefreshTokenServiceImpl.java
@@ -1,0 +1,20 @@
+package com.example.univeus.domain.auth.service;
+
+import com.example.univeus.domain.auth.repository.RefreshTokenRepository;
+import com.example.univeus.domain.auth.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public Boolean isExist(String id) {
+        return refreshTokenRepository.findById(id)
+                .isPresent();
+    }
+}

--- a/src/main/java/com/example/univeus/domain/member/Member.java
+++ b/src/main/java/com/example/univeus/domain/member/Member.java
@@ -10,10 +10,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 @Table(uniqueConstraints = {
         @UniqueConstraint(name = "member_email_unique", columnNames = {"email"}),
         @UniqueConstraint(name = "member_nickname_unique", columnNames = {"nickname"}),
@@ -46,4 +50,17 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     private Department department;
+
+    public static Member create(String email, String nickname, String studentId, String phoneNumber,
+                                Gender gender, Membership membership, Department department) {
+        return Member.builder()
+                .email(email)
+                .nickname(nickname)
+                .studentId(studentId)
+                .phoneNumber(phoneNumber)
+                .gender(gender)
+                .membership(membership)
+                .department(department)
+                .build();
+    }
 }

--- a/src/test/java/com/example/univeus/domain/auth/RefreshTokenExtractorTest.java
+++ b/src/test/java/com/example/univeus/domain/auth/RefreshTokenExtractorTest.java
@@ -1,0 +1,72 @@
+package com.example.univeus.domain.auth;
+
+import static com.example.univeus.common.exception.ErrorCode.REFRESH_TOKEN_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.example.univeus.domain.auth.exception.TokenException;
+import com.example.univeus.domain.auth.service.RefreshTokenService;
+import com.example.univeus.domain.auth.service.RefreshTokenTestService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenExtractorTest {
+    private RefreshTokenExtractor refreshTokenExtractor;
+
+    @BeforeEach
+    void setUp() {
+        RefreshTokenService refreshTokenService = new RefreshTokenTestService();
+        refreshTokenExtractor = new RefreshTokenExtractor(refreshTokenService);
+    }
+
+    @Test
+    void 유효한_토큰을_추출한다() {
+        // given
+        Cookie[] cookies = {
+                new Cookie("test", "testDummy"),
+                new Cookie("refresh-token", "validToken"),
+        };
+
+        // when
+        String actualTokenValue = refreshTokenExtractor.extractToken(cookies);
+
+        // then
+        Assertions.assertEquals("validToken", actualTokenValue);
+    }
+
+    @Test
+    void 존재하지_않는_토큰이라면_예외를_반환한다() {
+        // given
+        Cookie[] cookies = {
+                new Cookie("test", "testDummy"),
+                new Cookie("refresh-token", "notExist")
+        };
+
+        // when
+        TokenException tokenException = assertThrows(TokenException.class, () -> {
+            refreshTokenExtractor.extractToken(cookies);
+        });
+
+        // then
+        assertEquals(REFRESH_TOKEN_NOT_FOUND, tokenException.getErrorCode());
+    }
+
+    @Test
+    void cookie에_토큰이_존재하지_않는다면_예외를_반환한다() {
+        // given
+        Cookie[] cookies = {
+                new Cookie("test", "testDummy"),
+                new Cookie("test2", "notExist")
+        };
+
+        // when
+        TokenException tokenException = assertThrows(TokenException.class, () -> {
+            refreshTokenExtractor.extractToken(cookies);
+        });
+
+        // then
+        assertEquals(REFRESH_TOKEN_NOT_FOUND, tokenException.getErrorCode());
+    }
+}

--- a/src/test/java/com/example/univeus/domain/auth/TokenExtractorTest.java
+++ b/src/test/java/com/example/univeus/domain/auth/TokenExtractorTest.java
@@ -1,0 +1,46 @@
+package com.example.univeus.domain.auth;
+
+import static com.example.univeus.common.exception.ErrorCode.ACCESS_TOKEN_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.univeus.domain.auth.exception.TokenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TokenExtractorTest {
+
+    private TokenExtractor tokenExtractor;
+
+    @BeforeEach
+    void setUp() {
+        tokenExtractor = new TokenExtractor();
+    }
+
+    @Test
+    void 토큰을_추출한다() {
+        // given
+        String expectedToken = "Bearer validToken";
+
+        // when
+        String actualToken = tokenExtractor.extractToken(expectedToken);
+
+        // then
+        assertEquals(expectedToken.substring(7), actualToken);
+    }
+
+    @Test
+    void 올바르지_않은_헤더_형태이면_토큰_추출을_실패한다() {
+        // given
+        String expectedToken = "invalidToken";
+
+        // when
+        TokenException tokenException = assertThrows(
+                TokenException.class, () -> {
+                    tokenExtractor.extractToken(expectedToken);
+                });
+
+        // then
+        assertEquals(ACCESS_TOKEN_NOT_FOUND, tokenException.getErrorCode());
+    }
+
+}

--- a/src/test/java/com/example/univeus/domain/auth/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/example/univeus/domain/auth/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,50 @@
+package com.example.univeus.domain.auth.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.example.univeus.domain.auth.model.RefreshToken;
+import com.example.univeus.domain.member.Department;
+import com.example.univeus.domain.member.Gender;
+import com.example.univeus.domain.member.Member;
+import com.example.univeus.domain.member.Membership;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class RefreshTokenRepositoryTest {
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+    private RefreshToken fixureRefreshToken;
+
+    @BeforeEach
+    void setUp() {
+        Member fixureMember = Member.create(
+                "testEmail",
+                "testNickname",
+                "testStudentId",
+                "testPhoneNumber",
+                Gender.MAN,
+                Membership.NORMAL,
+                Department.ART_AND_PHYSICS
+        );
+
+        fixureRefreshToken = RefreshToken.create("testToken", fixureMember);
+    }
+
+    @Test
+    void 조회_기능을_테스트한다() {
+        // given
+        RefreshToken createdRefreshToken = refreshTokenRepository.save(fixureRefreshToken);
+
+        // when
+        RefreshToken findRefreshToken = refreshTokenRepository.findById(fixureRefreshToken.getTokenValue())
+                .orElse(null);
+
+        // then
+        assertEquals(createdRefreshToken.getTokenValue(), findRefreshToken.getTokenValue());
+        assertEquals(createdRefreshToken.getMember(), findRefreshToken.getMember());
+    }
+}

--- a/src/test/java/com/example/univeus/domain/auth/service/RefreshTokenTestService.java
+++ b/src/test/java/com/example/univeus/domain/auth/service/RefreshTokenTestService.java
@@ -1,0 +1,8 @@
+package com.example.univeus.domain.auth.service;
+
+public class RefreshTokenTestService implements RefreshTokenService {
+    @Override
+    public Boolean isExist(String id) {
+        return !id.equals("notExist");
+    }
+}


### PR DESCRIPTION
## 🥇 내용 소개
- ArgumentResolver를 통해서 인증 인가를 구현하였습니다
- token의 유효 기간 문제로 인한 exception이 아닌 exception에 대해서는 GUEST ROLE을 반환합니다


## 🔍 추후에 할 것
- 추후에 jwt의 세부적인 예외에 따라 response를 나누어야 한다


## 🧷 관련 issue
closed #5 