### PR TITLE
FEAT : 컨트롤러 단에서의 접근자의 권한체크를 Spring AOP를 이용해 구현한다

### DIFF
--- a/src/main/java/com/example/univeus/common/annotation/MemberOnly.java
+++ b/src/main/java/com/example/univeus/common/annotation/MemberOnly.java
@@ -1,0 +1,11 @@
+package com.example.univeus.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberOnly {
+}

--- a/src/main/java/com/example/univeus/domain/auth/MemberOnlyChecker.java
+++ b/src/main/java/com/example/univeus/domain/auth/MemberOnlyChecker.java
@@ -1,0 +1,25 @@
+package com.example.univeus.domain.auth;
+
+import com.example.univeus.common.exception.ErrorCode;
+import com.example.univeus.domain.auth.exception.AuthException;
+import com.example.univeus.domain.auth.model.Accessor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+
+@Aspect
+@Component
+public class MemberOnlyChecker {
+    @Before("@annotation(MemberOnly)")
+    public void check(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+
+        for (Object arg : args) {
+            if (arg instanceof Accessor accessor && !accessor.isMember()) {
+                throw new AuthException(ErrorCode.AUTH_BAD_REQUEST);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/univeus/domain/auth/model/Accessor.java
+++ b/src/main/java/com/example/univeus/domain/auth/model/Accessor.java
@@ -24,4 +24,8 @@ public class Accessor {
     public static Accessor of(AccessorRole accessRole, Long memberId) {
         return new Accessor(accessRole, memberId);
     }
+
+    public Boolean isMember() {
+        return accessorRole == AccessorRole.MEMBER;
+    }
 }

--- a/src/main/java/com/example/univeus/domain/auth/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/example/univeus/domain/auth/service/RefreshTokenServiceImpl.java
@@ -1,7 +1,6 @@
 package com.example.univeus.domain.auth.service;
 
 import com.example.univeus.domain.auth.repository.RefreshTokenRepository;
-import com.example.univeus.domain.auth.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
## 🥇 내용 소개
- spring aop를 횡단 관심사인 "권한 체크"를 메인 로직으로부터 분리한다
- 접근자의 role이 member가 아닐 경우, 예외를 발생시켜 컨트롤러 메서드를 호출하지 않는다
- 커스텀 어노테이션을 메서드에 붙여서 aop target을 특정한다

## 🔍 추후에 할 것
테스트 코드 작성

## 🧷 관련 issue
closed #7 