### PR TITLE
REFACTOR : 인증인가 도메인에 맞지 않는 코드 분리

### DIFF
--- a/src/main/java/com/example/univeus/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/univeus/domain/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package com.example.univeus.domain.auth.service;
 
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Nickname;
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Profile;
 import com.example.univeus.presentation.auth.dto.response.AuthResponse.ResponseTokens;
 
 public interface AuthService {
@@ -10,8 +8,4 @@ public interface AuthService {
     ResponseTokens issueTokens(Long memberId);
 
     ResponseTokens createOrLogin(String uri);
-
-    void registerProfile(Long memberId, Profile profileRequest);
-
-    void checkNicknameDuplicated(Nickname nicknameRequest);
 }

--- a/src/main/java/com/example/univeus/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/univeus/domain/auth/service/AuthServiceImpl.java
@@ -1,20 +1,13 @@
 package com.example.univeus.domain.auth.service;
 
 
-import static com.example.univeus.common.response.ResponseMessage.*;
-
 import com.example.univeus.domain.auth.GoogleServerLogin.Response;
 import com.example.univeus.domain.auth.SocialLogin;
 import com.example.univeus.domain.auth.TokenProvider;
 import com.example.univeus.domain.auth.dto.UserTokens;
 import com.example.univeus.domain.auth.model.RefreshToken;
-import com.example.univeus.domain.member.exception.MemberException;
-import com.example.univeus.domain.member.model.Department;
-import com.example.univeus.domain.member.model.Gender;
 import com.example.univeus.domain.member.model.Member;
 import com.example.univeus.domain.member.service.MemberService;
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Nickname;
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Profile;
 import com.example.univeus.presentation.auth.dto.response.AuthResponse.ResponseTokens;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
@@ -39,6 +32,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
 
+    @Override
     public ResponseTokens issueTokens(Long memberId) {
         UserTokens userTokens = tokenProvider.generateTokens(memberId.toString());
         Member member = memberService.findById(memberId);
@@ -58,22 +52,5 @@ public class AuthServiceImpl implements AuthService {
         member.checkProceed();
 
         return issueTokens(member.getId());
-    }
-
-    @Override
-    public void registerProfile(Long memberId, Profile profileRequest) {
-        Department department = Department.of(profileRequest.department());
-        Gender gender = Gender.of(profileRequest.gender());
-
-        memberService.updateProfile(memberId, department, gender, profileRequest.nickname(),
-                profileRequest.studentId());
-    }
-
-    @Override
-    public void checkNicknameDuplicated(Nickname nicknameRequest) {
-        String nickname = nicknameRequest.nickname();
-        if (memberService.findByNickname(nickname).isPresent()) {
-            throw new MemberException(MEMBER_NICKNAME_DUPLICATED);
-        }
     }
 }

--- a/src/main/java/com/example/univeus/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/univeus/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.univeus.domain.member.service;
 import com.example.univeus.domain.member.model.Department;
 import com.example.univeus.domain.member.model.Gender;
 import com.example.univeus.domain.member.model.Member;
+import com.example.univeus.presentation.member.dto.request.MemberRequest;
 import java.util.Optional;
 
 public interface MemberService {
@@ -19,4 +20,8 @@ public interface MemberService {
     Optional<Member> findByNickname(String nickname);
 
     void updatePhoneNumber(Long memberId, String phoneNumber);
+
+    void registerProfile(Long memberId, MemberRequest.Profile profileRequest);
+
+    void checkNicknameDuplicated(MemberRequest.Nickname nicknameRequest);
 }

--- a/src/main/java/com/example/univeus/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/univeus/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,8 @@ import com.example.univeus.domain.member.model.Gender;
 import com.example.univeus.domain.member.model.Member;
 import com.example.univeus.domain.member.exception.MemberException;
 import com.example.univeus.domain.member.repository.MemberRepository;
+import com.example.univeus.presentation.member.dto.request.MemberRequest.Nickname;
+import com.example.univeus.presentation.member.dto.request.MemberRequest.Profile;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -69,5 +71,22 @@ public class MemberServiceImpl implements MemberService {
                 member.getStudentId(),
                 phoneNumber
         );
+    }
+
+    @Override
+    public void registerProfile(Long memberId, Profile profileRequest) {
+        Department department = Department.of(profileRequest.department());
+        Gender gender = Gender.of(profileRequest.gender());
+
+        updateProfile(memberId, department, gender, profileRequest.nickname(),
+                profileRequest.studentId());
+    }
+
+    @Override
+    public void checkNicknameDuplicated(Nickname nicknameRequest) {
+        String nickname = nicknameRequest.nickname();
+        if (findByNickname(nickname).isPresent()) {
+            throw new MemberException(MEMBER_NICKNAME_DUPLICATED);
+        }
     }
 }

--- a/src/main/java/com/example/univeus/presentation/auth/controller/AuthController.java
+++ b/src/main/java/com/example/univeus/presentation/auth/controller/AuthController.java
@@ -7,12 +7,9 @@ import com.example.univeus.common.annotation.Auth;
 import com.example.univeus.common.annotation.MemberOnly;
 import com.example.univeus.common.response.Response;
 import com.example.univeus.domain.auth.dto.AccessToken;
-import com.example.univeus.domain.auth.model.Accessor;
 import com.example.univeus.domain.auth.service.AuthService;
 import com.example.univeus.domain.auth.service.SmsCertificationService;
 import com.example.univeus.presentation.auth.dto.request.AuthRequest.Login;
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Nickname;
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Profile;
 import com.example.univeus.presentation.auth.dto.response.AuthResponse.ResponseTokens;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -64,34 +61,6 @@ public class AuthController {
                         LOGIN_SUCCESS.getCode(),
                         LOGIN_SUCCESS.getMessage(),
                         loginResult.accessToken()
-                ));
-    }
-
-    @MemberOnly
-    @PostMapping("/profile")
-    public ResponseEntity<Response<String>> registerProfile(
-            @Auth Accessor accessor,
-            @Valid @RequestBody Profile profileRequest
-    ) {
-        authService.registerProfile(accessor.getMemberId(), profileRequest);
-        return ResponseEntity
-                .ok()
-                .body(Response.success(
-                        PROFILE_REGISTER_SUCCESS.getCode(),
-                        PROFILE_REGISTER_SUCCESS.getMessage()
-                ));
-    }
-
-    @PostMapping("/nickname/duplicated")
-    public ResponseEntity<Response<String>> checkNicknameDuplicated(
-            @Valid @RequestBody Nickname nicknameRequest
-    ) {
-        authService.checkNicknameDuplicated(nicknameRequest);
-        return ResponseEntity
-                .ok()
-                .body(Response.success(
-                        CHECK_NICKNAME_DUPLICATED_SUCCESS.getCode(),
-                        CHECK_NICKNAME_DUPLICATED_SUCCESS.getMessage()
                 ));
     }
 

--- a/src/main/java/com/example/univeus/presentation/auth/dto/request/AuthRequest.java
+++ b/src/main/java/com/example/univeus/presentation/auth/dto/request/AuthRequest.java
@@ -15,36 +15,6 @@ public class AuthRequest {
         }
     }
 
-    public record Profile(
-            @NotBlank(message = "닉네임은 공백이 될 수 없습니다.")
-            @Size(min = 1, max = 30, message = "닉네임의 길이는 1이상 30이하입니다.")
-            String nickname,
-
-            @NotBlank(message = "학과는 공백이 될 수 없습니다.")
-            String department,
-
-            @NotBlank(message = "성별은 공백이 될 수 없습니다.")
-            String gender,
-
-            @NotBlank(message = "학번은 공백이 될 수 없습니다.")
-            @Size(min = 1, max = 30, message = "학번의 길이는 1이상 30이하입니다.")
-            String studentId
-    ) {
-        public static Profile of(
-                String nickname, String department, String gender, String studentId) {
-            return new Profile(nickname, department, gender, studentId);
-        }
-    }
-
-    public record Nickname(
-            @NotBlank(message = "닉네임은 공백이 될 수 없습니다.")
-            String nickname
-    ) {
-        public static Nickname of(String nickname) {
-            return new Nickname(nickname);
-        }
-    }
-
     public record PhoneNumber(
             @NotBlank(message = "휴대폰 번호는 공백이 될 수 없습니다.")
             @Size(min = 9, max = 11, message = "휴대폰 번호의 길이가 올바르지 않습니다.")

--- a/src/main/java/com/example/univeus/presentation/member/controller/MemberController.java
+++ b/src/main/java/com/example/univeus/presentation/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.example.univeus.presentation.member.controller;
 
+import static com.example.univeus.common.response.ResponseMessage.CHECK_NICKNAME_DUPLICATED_SUCCESS;
+import static com.example.univeus.common.response.ResponseMessage.PROFILE_REGISTER_SUCCESS;
 import static com.example.univeus.common.response.ResponseMessage.UPDATE_PHONE_NUMBER_SUCCESS;
 import static com.example.univeus.presentation.member.dto.request.MemberRequest.*;
 
@@ -8,10 +10,13 @@ import com.example.univeus.common.annotation.MemberOnly;
 import com.example.univeus.common.response.Response;
 import com.example.univeus.domain.auth.model.Accessor;
 import com.example.univeus.domain.member.service.MemberService;
+import com.example.univeus.presentation.auth.dto.request.AuthRequest;
+import com.example.univeus.presentation.member.dto.request.MemberRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,7 +32,7 @@ public class MemberController {
     @PatchMapping("/phone")
     public ResponseEntity<Response<String>> updatePhoneNumber(
             @Auth Accessor accessor,
-            @RequestBody @Valid PhoneNumber phoneNumberRequest
+            @Valid @RequestBody PhoneNumber phoneNumberRequest
     ) {
         Long memberId = accessor.getMemberId();
         memberService.updatePhoneNumber(memberId, phoneNumberRequest.phoneNumber());
@@ -37,6 +42,34 @@ public class MemberController {
                 .body(Response.success(
                         UPDATE_PHONE_NUMBER_SUCCESS.getCode(),
                         UPDATE_PHONE_NUMBER_SUCCESS.getMessage()
+                ));
+    }
+
+    @MemberOnly
+    @PostMapping("/profile")
+    public ResponseEntity<Response<String>> registerProfile(
+            @Auth Accessor accessor,
+            @Valid @RequestBody MemberRequest.Profile profileRequest
+    ) {
+        memberService.registerProfile(accessor.getMemberId(), profileRequest);
+        return ResponseEntity
+                .ok()
+                .body(Response.success(
+                        PROFILE_REGISTER_SUCCESS.getCode(),
+                        PROFILE_REGISTER_SUCCESS.getMessage()
+                ));
+    }
+
+    @PostMapping("/nickname/duplicated")
+    public ResponseEntity<Response<String>> checkNicknameDuplicated(
+            @Valid @RequestBody MemberRequest.Nickname nicknameRequest
+    ) {
+        memberService.checkNicknameDuplicated(nicknameRequest);
+        return ResponseEntity
+                .ok()
+                .body(Response.success(
+                        CHECK_NICKNAME_DUPLICATED_SUCCESS.getCode(),
+                        CHECK_NICKNAME_DUPLICATED_SUCCESS.getMessage()
                 ));
     }
 }

--- a/src/main/java/com/example/univeus/presentation/member/dto/request/MemberRequest.java
+++ b/src/main/java/com/example/univeus/presentation/member/dto/request/MemberRequest.java
@@ -15,4 +15,34 @@ public class MemberRequest {
             return new PhoneNumber(phoneNumber);
         }
     }
+
+    public record Profile(
+            @NotBlank(message = "닉네임은 공백이 될 수 없습니다.")
+            @Size(min = 1, max = 30, message = "닉네임의 길이는 1이상 30이하입니다.")
+            String nickname,
+
+            @NotBlank(message = "학과는 공백이 될 수 없습니다.")
+            String department,
+
+            @NotBlank(message = "성별은 공백이 될 수 없습니다.")
+            String gender,
+
+            @NotBlank(message = "학번은 공백이 될 수 없습니다.")
+            @Size(min = 1, max = 30, message = "학번의 길이는 1이상 30이하입니다.")
+            String studentId
+    ) {
+        public static Profile of(
+                String nickname, String department, String gender, String studentId) {
+            return new Profile(nickname, department, gender, studentId);
+        }
+    }
+
+    public record Nickname(
+            @NotBlank(message = "닉네임은 공백이 될 수 없습니다.")
+            String nickname
+    ) {
+        public static Nickname of(String nickname) {
+            return new Nickname(nickname);
+        }
+    }
 }

--- a/src/test/java/com/example/univeus/domain/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/example/univeus/domain/auth/service/AuthServiceImplTest.java
@@ -1,18 +1,13 @@
 package com.example.univeus.domain.auth.service;
 
-import static com.example.univeus.common.response.ResponseMessage.*;
-import static com.example.univeus.common.response.ResponseMessage.DEPARTMENT_NOT_FOUND;
-import static com.example.univeus.common.response.ResponseMessage.GENDER_NOT_FOUND;
 import static com.example.univeus.common.response.ResponseMessage.MEMBER_NOT_AUTHORIZED_PHONE;
 import static com.example.univeus.common.response.ResponseMessage.MEMBER_NOT_AUTHORIZED_PROFILE;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
-import com.example.univeus.common.response.ResponseMessage;
 import com.example.univeus.domain.auth.GoogleServerLogin.Response;
 import com.example.univeus.domain.auth.SocialLogin;
 import com.example.univeus.domain.auth.TokenProvider;
@@ -24,11 +19,7 @@ import com.example.univeus.domain.member.model.Gender;
 import com.example.univeus.domain.member.model.Member;
 import com.example.univeus.domain.member.model.Membership;
 import com.example.univeus.domain.member.service.MemberService;
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Nickname;
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Profile;
 import com.example.univeus.presentation.auth.dto.response.AuthResponse.ResponseTokens;
-import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -233,115 +224,6 @@ class AuthServiceImplTest {
 
             // then
             assertEquals(MEMBER_NOT_AUTHORIZED_PROFILE, memberException.getResponseMessage());
-        }
-    }
-
-    @Nested
-    @DisplayName("프로필을 등록한다")
-    class TestRegisterProfile {
-
-        @Test
-        void 프로필_등록을_성공한다() {
-            // given
-            Long memberId = 1L;
-            Profile profile = Profile.of(
-                    "testNickname",
-                    "인문대학",
-                    "WOMAN",
-                    "testStudentId"
-            );
-
-            // when
-            authService.registerProfile(memberId, profile);
-
-            // then
-            assertDoesNotThrow(() ->
-                    authService.registerProfile(memberId, profile));
-        }
-
-        @Test
-        void 성별이_올바르지_않게_입력될_경우_프로필_등록을_실패한다() {
-            // given
-            Long memberId = 1L;
-            Profile profile = Profile.of(
-                    "testNickname",
-                    "인문대학",
-                    "WO",
-                    "testStudentId"
-            );
-
-            // when
-            MemberException memberException = assertThrows(
-                    MemberException.class, () ->
-                            authService.registerProfile(memberId, profile));
-
-            // then
-            assertEquals(GENDER_NOT_FOUND, memberException.getResponseMessage());
-        }
-
-        @Test
-        void 학과가_올바르지_않게_입력될_경우_프로필_등록을_실패한다() {
-            // given
-            Long memberId = 1L;
-            Profile profile = Profile.of(
-                    "testNickname",
-                    "인문",
-                    "WOMAN",
-                    "testStudentId"
-            );
-
-            // when
-            MemberException memberException = assertThrows(
-                    MemberException.class, () ->
-                            authService.registerProfile(memberId, profile));
-
-            // then
-            assertEquals(DEPARTMENT_NOT_FOUND, memberException.getResponseMessage());
-        }
-    }
-
-    @Nested
-    @DisplayName("닉네임 중복체크를 수행한다.")
-    class TestNicknameDuplicated {
-
-        Member member = new Member(
-                1L,
-                "testEmail",
-                "testNickName",
-                null,
-                "testPhoneNumber",
-                null,
-                null,
-                null
-        );
-
-        @Test
-        void 닉네임이_중복되지_않는다() {
-            // given
-            Nickname nicknameRequest = Nickname.of("newNickname");
-            when(memberService.findByNickname(any())).thenReturn(Optional.empty());
-
-
-
-            // when then
-            assertDoesNotThrow(() ->
-                    authService.checkNicknameDuplicated(nicknameRequest)
-            );
-        }
-
-        @Test
-        void 닉네임이_중복된다면_예외를_던진다() {
-            // given
-            Nickname nicknameRequest = Nickname.of("testNickname");
-            when(memberService.findByNickname(any())).thenReturn(Optional.ofNullable(member));
-
-            // when
-            MemberException memberException = assertThrows(MemberException.class,
-                    () -> authService.checkNicknameDuplicated(nicknameRequest)
-            );
-
-            // then
-            Assertions.assertEquals(MEMBER_NICKNAME_DUPLICATED, memberException.getResponseMessage());
         }
     }
 }

--- a/src/test/java/com/example/univeus/presentation/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/univeus/presentation/auth/controller/AuthControllerTest.java
@@ -2,11 +2,9 @@ package com.example.univeus.presentation.auth.controller;
 
 import static com.example.univeus.common.response.ResponseMessage.CERTIFICATION_REQUEST_SUCCESS;
 import static com.example.univeus.common.response.ResponseMessage.CERTIFICATION_VERIFY_SUCCESS;
-import static com.example.univeus.common.response.ResponseMessage.CHECK_NICKNAME_DUPLICATED_SUCCESS;
 import static com.example.univeus.common.response.ResponseMessage.LOGIN_SUCCESS;
 import static com.example.univeus.common.response.ResponseMessage.MEMBER_NOT_AUTHORIZED_PHONE;
 import static com.example.univeus.common.response.ResponseMessage.MEMBER_NOT_AUTHORIZED_PROFILE;
-import static com.example.univeus.common.response.ResponseMessage.PROFILE_REGISTER_SUCCESS;
 import static com.example.univeus.common.response.ResponseMessage.REFRESH_TOKEN_NOT_FOUND;
 import static com.example.univeus.common.response.ResponseMessage.REISSUE_TOKEN_SUCCESS;
 import static org.hamcrest.Matchers.*;
@@ -26,7 +24,6 @@ import com.example.univeus.presentation.BaseControllerTest;
 import com.example.univeus.presentation.auth.dto.request.AuthRequest;
 import com.example.univeus.presentation.auth.dto.request.AuthRequest.Certification;
 import com.example.univeus.presentation.auth.dto.request.AuthRequest.PhoneNumber;
-import com.example.univeus.presentation.auth.dto.request.AuthRequest.Profile;
 import com.example.univeus.presentation.auth.dto.response.AuthResponse.ResponseTokens;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
@@ -221,112 +218,6 @@ class AuthControllerTest extends BaseControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(MEMBER_NOT_AUTHORIZED_PROFILE.getCode()))
                     .andExpect(jsonPath("$.message").value(MEMBER_NOT_AUTHORIZED_PROFILE.getMessage()));
-        }
-    }
-
-    @Nested
-    @DisplayName("프로필 등록 테스트")
-    class TestRegisterProfile {
-
-        @Test
-        void 올바른_형식으로_요청을_보낼경우_예외가_발생하지_않는다() throws Exception {
-
-            AuthRequest.Profile profile = Profile.of(
-                    "nickname",
-                    "department",
-                    "gender",
-                    "studentId"
-            );
-
-            ResultActions resultActions =
-                    mockMvc.perform(post("/api/v1/auth/profile")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(profile)));
-
-            resultActions
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath(("$.code")).value(PROFILE_REGISTER_SUCCESS.getCode()))
-                    .andExpect(jsonPath(("$.message")).value(PROFILE_REGISTER_SUCCESS.getMessage()));
-        }
-
-        @ParameterizedTest
-        @MethodSource("provideProfiles")
-        void 올바르지_않은_프로필_등록_요청을_보낼경우_예외가_발생한다(
-                String nickname, String department, String gender, String studentId
-        ) throws Exception {
-
-            AuthRequest.Profile profile = AuthRequest.Profile.of(
-                    nickname,
-                    department,
-                    gender,
-                    studentId
-            );
-
-            ResultActions resultActions =
-                    mockMvc.perform(post("/api/v1/auth/profile")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(profile)));
-
-            resultActions
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath(("$.code")).value("FORMAT-001"));
-        }
-
-        private static Stream<Arguments> provideProfiles() {
-            return Stream.of(
-                    Arguments.of("", "department", "gender", "studentId"),       // 닉네임이 공백
-                    Arguments.of("nickname", "", "gender", "studentId"),        // 학과가 공백
-                    Arguments.of("nickname", "department", "", "studentId"),    // 성별이 공백
-                    Arguments.of("nickname", "department", "gender", "")        // 학번이 공백
-            );
-        }
-
-        @Nested
-        @DisplayName("닉네임 중복 테스트")
-        class TestCheckNicknameDuplicated {
-
-            @Test
-            void 올바른_형식으로_요청을_보낼경우_예외가_발생하지_않는다() throws Exception {
-
-                // given
-                AuthRequest.Nickname nicknameRequest = AuthRequest.Nickname.of("testNickname");
-
-                // when
-                ResultActions resultActions =
-                        mockMvc
-                                .perform(post("/api/v1/auth/nickname/duplicated")
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .content(objectMapper.writeValueAsString(nicknameRequest)));
-
-                // then
-                resultActions
-                        .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.code").value(CHECK_NICKNAME_DUPLICATED_SUCCESS.getCode()))
-                        .andExpect(jsonPath("$.message").value(CHECK_NICKNAME_DUPLICATED_SUCCESS.getMessage()));
-            }
-
-
-            @ParameterizedTest
-            @ValueSource(strings = {"", " ", "    "})
-            void 닉네임이_올바른_입력이_아닐경우_예외를_던진다(String nickname) throws Exception {
-
-                // given
-                AuthRequest.Nickname nicknameRequest = AuthRequest.Nickname.of(nickname);
-
-                // when
-                ResultActions resultActions =
-                        mockMvc
-                                .perform(post("/api/v1/auth/nickname/duplicated")
-                                        .contentType(MediaType.APPLICATION_JSON)
-                                        .content(objectMapper.writeValueAsString(nicknameRequest)));
-
-                // then
-                resultActions
-                        .andExpect(status().isBadRequest())
-                        .andExpect(jsonPath("$.status").value(false))
-                        .andExpect(jsonPath("$.code").value("FORMAT-001"))
-                        .andExpect(jsonPath("$.message").value("닉네임은 공백이 될 수 없습니다."));
-            }
         }
     }
 


### PR DESCRIPTION
## 🥇 내용 소개
- 유저 도메인에 가까운 프로필 등록로직을, 인증인가 도메인에서 분리한다
- 유저 도메인에 가까운 닉네임 중복체크 로직을, 인증인가 도메인에서 분리한다

## 🔍 추후에 할 것


## 🧷 관련 issue
closed #17 