### PR TITLE
FIX : Main Page의 커서가 조회되지 않는 문제를 해결한다

### DIFF
--- a/src/main/java/com/example/univeus/domain/meeting/repository/MeetingPostRepository.java
+++ b/src/main/java/com/example/univeus/domain/meeting/repository/MeetingPostRepository.java
@@ -53,11 +53,11 @@ public interface MeetingPostRepository extends JpaRepository<MeetingPost, Long> 
             "SELECT p FROM MeetingPost p " +
                     "WHERE (:category IS NULL OR p.meetingCategory = :category) " +
                     "AND (:cursorId IS NULL OR p.id < :cursorId) " +
-                    "ORDER BY p.id DESC"
+                    "ORDER BY p.id DESC " +
+                    "LIMIT 20"
     )
     List<MeetingPost> findByCategoryAndOptionalCursor(
             @Param("category") MeetingCategory category,
-            @Param("cursorId") Long cursorId,
-            Pageable pageable
+            @Param("cursorId") Long cursorId
     );
 }

--- a/src/main/java/com/example/univeus/domain/meeting/service/MainPageServiceImpl.java
+++ b/src/main/java/com/example/univeus/domain/meeting/service/MainPageServiceImpl.java
@@ -22,10 +22,8 @@ public class MainPageServiceImpl implements MainPageService {
 
     @Override
     public MainPage getMainPage(Long cursor, MeetingCategory meetingCategory) {
-        Pageable pageable = PageRequest.of(0, SIZE); // 페이지 크기만 지정
         List<MeetingPost> meetingPosts = meetingPostRepository.findByCategoryAndOptionalCursor(meetingCategory,
-                cursor,
-                pageable);
+                cursor);
 
         List<MainPageDetail> mainPages = meetingPosts.stream().map(MainPageMapper::toMainPageDetail).toList();
 
@@ -33,7 +31,7 @@ public class MainPageServiceImpl implements MainPageService {
             return new MainPage(mainPages, "NONE", false);
         }
 
-        String nextCursor = meetingPosts.get(meetingPosts.size() - 1).toString();
+        String nextCursor = String.valueOf(meetingPosts.get(meetingPosts.size() - 1).getId());
         return new MainPage(mainPages, nextCursor, true);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,10 +28,10 @@ spring:
       hibernate:
         default_batch_fetch_size: 100  # 기본 배치 크기 설정
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
     show-sql: true
-    database-platform: org.hibernate.dialect.H2Dialect
+#    database-platform: org.hibernate.dialect.H2Dialect
   profiles:
     include:
       - jwt


### PR DESCRIPTION
- id를 이용하여 cursor를 만들어야 하는데, id를 추출하지 않아 cursor가 올바르게 반환 되지 않는 문제가 발생
- id를 제대로 추출하여 String.valueOf를 통해 타입을 변환하여 반환한다

- cursor 기반 페이징에서 pageable 없이 쿼리를 작성한다
- 불필요한 OFFSET 사용을 방지한다

closed #50 